### PR TITLE
fix(deps): remove unused dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next/core-web-vitals"]
+}
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@date-fns/utc": "^1.2.0",
-    "@prisma/client": "^5.12.1",
+
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-switch": "^1.1.0",
@@ -23,7 +23,7 @@
     "@tanstack/react-query": "^5.28.9",
     "@tanstack/react-query-devtools": "^5.28.9",
     "@tanstack/react-table": "^8.21.2",
-    "@uidotdev/usehooks": "^2.4.1",
+
     "axios": "^1.6.8",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
@@ -34,7 +34,7 @@
     "drizzle-orm": "latest",
     "jsonwebtoken": "^9.0.2",
     "next": "latest",
-    "next-auth": "^4.24.7",
+
     "next-themes": "^0.3.0",
     "pg": "^8.12.0",
     "react": "^18",

--- a/src/components/Calendar/main.tsx
+++ b/src/components/Calendar/main.tsx
@@ -22,7 +22,6 @@ import {
 import { useVisibilityChange } from "@/lib/useVisibilityChange";
 import { UTCDate } from "@date-fns/utc";
 import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons";
-// import { useMouse } from "@uidotdev/usehooks";
 import {
   addDays,
   addMinutes,


### PR DESCRIPTION
## Summary
Removes three unused packages that were increasing bundle size with no benefit.

| Package | Reason removed |
|---|---|
| `@prisma/client` | Drizzle ORM is used exclusively for DB access |
| `next-auth` | Custom Microsoft OAuth2 implementation is used instead |
| `@uidotdev/usehooks` | Only referenced in a commented-out import |

## Changes
- `package.json` — remove 3 dependencies
- `src/components/Calendar/main.tsx` — remove commented-out `useMouse` import
- `.eslintrc.json` — add ESLint config (Next.js 14 compatible)

## Verification
- `bun install` ran cleanly — 3 packages removed
- `bun run lint` passes with no errors

Closes #1