### PR TITLE
fix(phase-3): architecture — SSE pool, auth headers, multi-tenancy, EventForm hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ bun.lockb
 
 # Drizzle
 drizzle/
+# Track Drizzle migrations in src/drizzle/ (they are schema artifacts, not local state)
+!src/drizzle/
 
 # Docker
 .dockerignore

--- a/src/app/api/(protected)/events/route.ts
+++ b/src/app/api/(protected)/events/route.ts
@@ -1,9 +1,8 @@
-import { Event, Events, NewEvent, User } from "@/db/schema";
+import { Events, NewEvent, User } from "@/db/schema";
 import { db } from "@/lib/db";
 import { createEvent, deleteEvent, updateEvent } from "@/lib/event";
 import { CreateEventSchema, DeleteByIdSchema, UpdateEventSchema } from "@/lib/schemas";
 import { and, eq, gte, lte } from "drizzle-orm";
-import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 function isValidDateString(dateString: string): boolean {
@@ -14,6 +13,9 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const dateStart = searchParams.get("dateStart");
   const dateEnd = searchParams.get("dateEnd");
+  // Filter events to the caller's society when the header is present.
+  const societyIdHeader = request.headers.get("x-society-id");
+  const societyId = societyIdHeader ? parseInt(societyIdHeader, 10) : null;
 
   try {
     const baseQuery = db
@@ -21,19 +23,26 @@ export async function GET(request: NextRequest) {
       .from(Events)
       .innerJoin(User, eq(User.microsoft_id, Events.microsoft_id));
 
+    const societyFilter = societyId
+      ? eq(Events.society_id, societyId)
+      : undefined;
+
     const rows = await (dateStart && dateEnd
       ? (() => {
           if (!isValidDateString(dateStart) || !isValidDateString(dateEnd)) {
             return null;
           }
+          const dateFilter = and(
+            gte(Events.dateStart, new Date(dateStart)),
+            lte(Events.dateEnd, new Date(dateEnd))
+          );
           return baseQuery.where(
-            and(
-              gte(Events.dateStart, new Date(dateStart)),
-              lte(Events.dateEnd, new Date(dateEnd))
-            )
+            societyFilter ? and(dateFilter, societyFilter) : dateFilter
           );
         })()
-      : baseQuery);
+      : societyFilter
+        ? baseQuery.where(societyFilter)
+        : baseQuery);
 
     if (rows === null) {
       return NextResponse.json(
@@ -55,26 +64,28 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const microsoftToken = cookies().get("token")?.value;
-  if (!microsoftToken)
-    return NextResponse.json({ error: "Token Invalid" }, { status: 401 });
-
   const rawBody = await request.json();
   const parsed = CreateEventSchema.safeParse(rawBody);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
   }
+
+  // Identity is resolved once in middleware and forwarded via x-ms-user-id header.
+  // This avoids a redundant MS Graph call per POST request.
+  const msUserId = request.headers.get("x-ms-user-id");
+  if (!msUserId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const societyIdHeader = request.headers.get("x-society-id");
+  const societyId = societyIdHeader ? parseInt(societyIdHeader, 10) : undefined;
+
   try {
-    const graphResponse = await axios.get(
-      "https://graph.microsoft.com/v1.0/me",
-      {
-        headers: {
-          Authorization: `Bearer ${microsoftToken}`,
-        },
-      }
-    );
-    // Overwrite microsoft_id with the value from the validated token — never trust the client.
-    const body: NewEvent = { ...parsed.data, microsoft_id: graphResponse.data.id };
+    const body: NewEvent = {
+      ...parsed.data,
+      microsoft_id: msUserId,
+      society_id: societyId,
+    };
     await createEvent(body);
     return NextResponse.json(
       { message: "Event succesfully created", status: 200 },

--- a/src/app/api/(protected)/events/updates/route.ts
+++ b/src/app/api/(protected)/events/updates/route.ts
@@ -1,27 +1,29 @@
 export const dynamic = "force-dynamic";
 
-import { db, pool } from "@/db";
+import { db, ssePool } from "@/db";
 import { Events, User } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
   const encoder = new TextEncoder();
-  const client = await pool.connect();
+  // Use the dedicated SSE pool so long-lived LISTEN connections do not
+  // exhaust slots in the shared API pool.
+  const client = await ssePool.connect();
   client.setMaxListeners(500);
-  let streamClosed = false; // Flag to track if the stream is already closed
+  let streamClosed = false;
 
   const cleanup = async () => {
     if (!streamClosed) {
-      streamClosed = true; // Mark stream as closed
+      streamClosed = true;
       await client.query("UNLISTEN event_changes");
-      client.release(); // Release client connection
+      client.release();
     }
   };
 
   const stream = new ReadableStream({
     async start(controller) {
-      const sendEvent = (data: any) => {
+      const sendEvent = (data: unknown) => {
         if (
           !streamClosed &&
           controller?.desiredSize !== null &&
@@ -30,7 +32,6 @@ export async function GET(request: NextRequest) {
           controller.enqueue(
             encoder.encode(`data: ${JSON.stringify(data)}\n\n`)
           );
-        } else {
         }
       };
 
@@ -38,9 +39,7 @@ export async function GET(request: NextRequest) {
         await client.query("LISTEN event_changes");
 
         client.on("notification", async (msg) => {
-          if (streamClosed) {
-            return; // Skip if stream is closed
-          }
+          if (streamClosed) return;
 
           const payload = JSON.parse(msg.payload as string);
 
@@ -48,15 +47,17 @@ export async function GET(request: NextRequest) {
           if (payload.operation === "DELETE") {
             eventData = { id: payload.id };
           } else {
-            const [event] = await db
-              //@ts-ignore
-              .select({ ...Events, user: User })
+            const rows = await db
+              .select()
               .from(Events)
               .innerJoin(User, eq(User.microsoft_id, Events.microsoft_id))
               .where(eq(Events.id, payload.id))
               .limit(1);
 
-            eventData = event || { id: payload.id };
+            const row = rows[0];
+            eventData = row
+              ? { ...row.events, user: row.users }
+              : { id: payload.id };
           }
 
           sendEvent({
@@ -65,26 +66,25 @@ export async function GET(request: NextRequest) {
           });
         });
 
-        // Keep-alive ping
+        // Keep-alive ping every 30 s
         const pingIntervalId = setInterval(() => {
           sendEvent({ type: "ping" });
         }, 30000);
 
-        // Cleanup function for when the response is closed
-        // https://github.com/vercel/next.js/discussions/48682 addEventListener("abort") doesn't work in next:14.2.3
-        // keep it until it works
+        // https://github.com/vercel/next.js/discussions/48682 — abort signal
+        // doesn't fire reliably in Next.js 14; clean up on best-effort basis.
         request.signal.addEventListener("abort", async () => {
           clearInterval(pingIntervalId);
           await cleanup();
-          // controller.close(); // Close the stream
         });
       } catch (error) {
-        console.error("Error setting up event listener:", error);
+        console.error("Error setting up SSE listener:", error);
         await cleanup();
-        controller.close(); // Close the stream
+        controller.close();
       }
     },
   });
+
   return new NextResponse(stream, {
     headers: {
       "Content-Type": "text/event-stream",

--- a/src/components/Calendar/calendaritem/EventForm.tsx
+++ b/src/components/Calendar/calendaritem/EventForm.tsx
@@ -1,12 +1,8 @@
 // @ts-nocheck
 import { useCalendarStore } from "@/app/calendar/providers/calendar-store-provider";
 import { FormValues } from "@/app/data/events";
-import {
-  createEvent,
-  deleteEvent,
-  getConflictsRooms,
-  updateEvent,
-} from "@/app/utils/queries";
+import { getConflictsRooms } from "@/app/utils/queries";
+import { useEventSubmit } from "@/lib/hooks/useEventSubmit";
 import { EventsResponseWithParentEventsDate } from "@/components/Calendar/types/types";
 import {
   ClockIcon,
@@ -25,7 +21,6 @@ import { formatInTimeZone } from "date-fns-tz";
 import { fr } from "date-fns/locale";
 import { Dispatch, SetStateAction, useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
-import toast from "react-hot-toast";
 
 export const EventForm = ({
   eventInfos,
@@ -39,7 +34,7 @@ export const EventForm = ({
   const state = useCalendarStore((state) => state);
   const roomOptions = state.rooms;
 
-  const { register, handleSubmit, setValue, reset, watch } =
+  const { register, handleSubmit, setValue, watch } =
     useForm<FormValues>({
       defaultValues: {
         subTag_id:
@@ -51,9 +46,17 @@ export const EventForm = ({
     });
   const dateStart = watch("dateStart");
   const subTag_id = watch("subTag_id");
-  const [isDisable, setDisable] = useState<boolean>(false);
 
-  const [isDisplayRooms, setisDisplayRooms] = useState<boolean>(false);
+  const [isDisplayRooms, setisDisplayRooms] = useState(false);
+
+  const { onSubmit: submitEvent, handleDeleteEvent, isDisable } = useEventSubmit({
+    eventInfos,
+    roomOptions,
+    setisModalOpen,
+    updateSSEdata: state.updateSSEdata,
+    updateIsNewPreviewDisplay: state.updateIsNewPreviewDisplay,
+    updateCreatePreviewInfos: state.updateCreatePreviewInfos,
+  });
 
   const {
     data: items = [],
@@ -67,79 +70,10 @@ export const EventForm = ({
         eventInfos.dateStart,
         eventInfos.dateEnd
       ),
-    enabled: isDisplayRooms, // Only fetch when the menu is open
+    enabled: isDisplayRooms,
   });
 
-  const onSubmit: SubmitHandler<FormValues> = async (data) => {
-    // ID === -1 CREATE else PUT
-    setDisable(true);
-    if (roomOptions.some((item) => item.name === data.subTag_id)) {
-      const findRoombySubtag = roomOptions.find(
-        (item) => item.name === data.subTag_id
-      )?.tag_id;
-      data.subTag_id = findRoombySubtag;
-      if (eventInfos.id === -42) {
-        const toastCreate = toast.loading("Chargement...");
-        try {
-          const res = await createEvent(data);
-          if (res.status === 200) {
-            toast.success(
-              `Salle ${data.name} pour ${formatInTimeZone(
-                data.dateStart,
-                "Europe/Paris",
-                "dd-MM-yyyy HH:mm",
-                { locale: fr }
-              )} à ${formatInTimeZone(
-                data.dateEnd,
-                "Europe/Paris",
-                "dd-MM-yyyy HH:mm",
-                { locale: fr }
-              )} réservée`,
-              { id: toastCreate }
-            );
-            setisModalOpen(false);
-            state.updateSSEdata({ id: -42 }, "delete");
-          } else {
-            toast.error(res?.message ?? "Erreur lors de la création", { id: toastCreate });
-          }
-        } catch (error) {
-          console.error("Error creating event:", error);
-          toast.error("Erreur lors de la création de l'évènement", { id: toastCreate });
-        } finally {
-          setDisable(false);
-        }
-      } else {
-        data.id = eventInfos.id;
-        try {
-          const res = await updateEvent(data, true);
-          if (res?.status === 403 && toast?.error) {
-            state.updateIsNewPreviewDisplay(false);
-            state.updateCreatePreviewInfos({
-              dates: { dateStart: "", dateEnd: "" },
-              origin: "",
-            });
-            toast.error(res?.error);
-          } else {
-            toast.success("Évènement a été modifié avec succès");
-            setisModalOpen(false);
-          }
-        } catch (e) {
-          toast.error("Erreur serveur");
-        } finally {
-          setDisable(false);
-        }
-      }
-    }
-  };
-
-  const handleDeleteEvent = () => {
-    toast.promise(deleteEvent(eventInfos), {
-      loading: "Loading",
-      success: `Évènement supprimé avec succès`,
-      error: "Erreur dans la suppression de l'évènement",
-    });
-    setisModalOpen(false);
-  };
+  const onSubmit: SubmitHandler<FormValues> = (data) => submitEvent(data);
 
   return (
     <>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,6 +4,15 @@ import * as schema from "./schema";
 
 export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  max: 10,
+});
+
+// Dedicated pool for SSE LISTEN/NOTIFY connections.
+// SSE clients hold a connection open indefinitely, so they must not compete
+// with regular API requests for slots in the shared pool.
+export const ssePool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 30,
 });
 
 export const db = drizzle(pool, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -106,6 +106,7 @@ export const Events = pgTable(TableInfos.events, {
   dateEnd: timestamp("date_end", { mode: "string" }).notNull(),
   subTag_id: integer("sub_tag_id").notNull(),
   microsoft_id: text("microsoft_id").notNull(),
+  society_id: integer("society_id"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/src/drizzle/0000_special_mattie_franklin.sql
+++ b/src/drizzle/0000_special_mattie_franklin.sql
@@ -1,0 +1,82 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."Role" AS ENUM('ADMIN', 'EDITOR', 'VIEWER');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"date_start" timestamp NOT NULL,
+	"date_end" timestamp NOT NULL,
+	"sub_tag_id" integer NOT NULL,
+	"microsoft_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "licences" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"price" integer NOT NULL,
+	"max_admins" integer NOT NULL,
+	"max_editors" integer NOT NULL,
+	"max_viewers" integer NOT NULL,
+	"url_share" boolean NOT NULL,
+	"active" boolean NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "rooms" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"color" text,
+	"tag_id" integer
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "societies" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"logo" text,
+	"url_share" text,
+	"licence_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "sub_tags" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"color" text NOT NULL,
+	"tag_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "tags" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"color" text NOT NULL,
+	"society_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"given_name" text NOT NULL,
+	"surname" text NOT NULL,
+	"microsoft_id" text NOT NULL,
+	"email" text NOT NULL,
+	"picture" text,
+	"role" "Role" DEFAULT 'VIEWER',
+	"society_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_microsoft_id_unique" UNIQUE("microsoft_id"),
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);

--- a/src/drizzle/0001_great_miss_america.sql
+++ b/src/drizzle/0001_great_miss_america.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN "society_id" integer;

--- a/src/drizzle/meta/0000_snapshot.json
+++ b/src/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,448 @@
+{
+  "id": "d649f5f7-6ed0-4727-a595-4443e5b42ff8",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_tag_id": {
+          "name": "sub_tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_id": {
+          "name": "microsoft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.licences": {
+      "name": "licences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_admins": {
+          "name": "max_admins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_editors": {
+          "name": "max_editors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_viewers": {
+          "name": "max_viewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_share": {
+          "name": "url_share",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.societies": {
+      "name": "societies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url_share": {
+          "name": "url_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licence_id": {
+          "name": "licence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sub_tags": {
+      "name": "sub_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_id": {
+          "name": "microsoft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'VIEWER'"
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_microsoft_id_unique": {
+          "name": "users_microsoft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "microsoft_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "EDITOR",
+        "VIEWER"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/0001_snapshot.json
+++ b/src/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,454 @@
+{
+  "id": "accb0301-73be-4d73-be6e-4456725ee739",
+  "prevId": "d649f5f7-6ed0-4727-a595-4443e5b42ff8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_tag_id": {
+          "name": "sub_tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_id": {
+          "name": "microsoft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.licences": {
+      "name": "licences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_admins": {
+          "name": "max_admins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_editors": {
+          "name": "max_editors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_viewers": {
+          "name": "max_viewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_share": {
+          "name": "url_share",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.societies": {
+      "name": "societies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url_share": {
+          "name": "url_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licence_id": {
+          "name": "licence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sub_tags": {
+      "name": "sub_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_id": {
+          "name": "microsoft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'VIEWER'"
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_microsoft_id_unique": {
+          "name": "users_microsoft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "microsoft_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "EDITOR",
+        "VIEWER"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1720083209459,
+      "tag": "0000_special_mattie_franklin",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775141544169,
+      "tag": "0001_great_miss_america",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/lib/hooks/useEventSubmit.ts
+++ b/src/lib/hooks/useEventSubmit.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { FormValues } from "@/app/data/events";
+import {
+  createEvent,
+  deleteEvent,
+  updateEvent,
+} from "@/app/utils/queries";
+import { EventsResponseWithParentEventsDate, Room } from "@/components/Calendar/types/types";
+import { formatInTimeZone } from "date-fns-tz";
+import { fr } from "date-fns/locale";
+import { Dispatch, SetStateAction, useState } from "react";
+import toast from "react-hot-toast";
+
+interface UseEventSubmitOptions {
+  eventInfos: EventsResponseWithParentEventsDate;
+  roomOptions: Room[];
+  setisModalOpen: Dispatch<SetStateAction<boolean>>;
+  updateSSEdata: (event: { id: number }, op: string) => void;
+  updateIsNewPreviewDisplay: (val: boolean) => void;
+  updateCreatePreviewInfos: (val: { dates: { dateStart: string; dateEnd: string }; origin: string }) => void;
+}
+
+export function useEventSubmit({
+  eventInfos,
+  roomOptions,
+  setisModalOpen,
+  updateSSEdata,
+  updateIsNewPreviewDisplay,
+  updateCreatePreviewInfos,
+}: UseEventSubmitOptions) {
+  const [isDisable, setDisable] = useState<boolean>(false);
+
+  const onSubmit = async (data: FormValues) => {
+    if (!roomOptions.some((item) => item.name === data.subTag_id)) return;
+
+    setDisable(true);
+
+    const room = roomOptions.find((item) => item.name === data.subTag_id);
+    data.subTag_id = room?.tag_id ?? data.subTag_id;
+
+    if (eventInfos.id === -42) {
+      // Create
+      const toastCreate = toast.loading("Chargement...");
+      try {
+        const res = await createEvent(data);
+        if (res.status === 200) {
+          toast.success(
+            `Salle ${data.name} pour ${formatInTimeZone(
+              data.dateStart,
+              "Europe/Paris",
+              "dd-MM-yyyy HH:mm",
+              { locale: fr }
+            )} à ${formatInTimeZone(
+              data.dateEnd,
+              "Europe/Paris",
+              "dd-MM-yyyy HH:mm",
+              { locale: fr }
+            )} réservée`,
+            { id: toastCreate }
+          );
+          setisModalOpen(false);
+          updateSSEdata({ id: -42 }, "delete");
+        } else {
+          toast.error(res?.message ?? "Erreur lors de la création", { id: toastCreate });
+        }
+      } catch (error) {
+        console.error("Error creating event:", error);
+        toast.error("Erreur lors de la création de l'évènement", { id: toastCreate });
+      } finally {
+        setDisable(false);
+      }
+    } else {
+      // Update
+      data.id = eventInfos.id;
+      try {
+        const res = await updateEvent(data, true);
+        if (res?.status === 403) {
+          updateIsNewPreviewDisplay(false);
+          updateCreatePreviewInfos({
+            dates: { dateStart: "", dateEnd: "" },
+            origin: "",
+          });
+          toast.error(res?.error);
+        } else {
+          toast.success("Évènement a été modifié avec succès");
+          setisModalOpen(false);
+        }
+      } catch (e) {
+        toast.error("Erreur serveur");
+      } finally {
+        setDisable(false);
+      }
+    }
+  };
+
+  const handleDeleteEvent = () => {
+    toast.promise(deleteEvent(eventInfos), {
+      loading: "Loading",
+      success: "Évènement supprimé avec succès",
+      error: "Erreur dans la suppression de l'évènement",
+    });
+    setisModalOpen(false);
+  };
+
+  return { onSubmit, handleDeleteEvent, isDisable };
+}

--- a/src/lib/middleware/protectedRoutes.ts
+++ b/src/lib/middleware/protectedRoutes.ts
@@ -4,19 +4,20 @@ import { NextResponse } from "next/server";
 export function protectedRoute(
   role: Role,
   method: HttpMethod,
-  pathname: string
+  pathname: string,
+  headers?: Headers
 ) {
+  const next = (status?: number) =>
+    status
+      ? new NextResponse("Insufficient Permissions", { status })
+      : NextResponse.next({ request: headers ? { headers } : undefined });
+
   switch (role) {
-    case "VIEWER": {
-      if (method !== "GET")
-        return new NextResponse("Unsifficient Permissions", { status: 401 });
-      else return NextResponse.next();
-    }
-    case "EDITOR": {
-      return NextResponse.next();
-    }
-    default: {
-      return new NextResponse("Unsifficient Permissions", { status: 401 });
-    }
+    case "VIEWER":
+      return method !== "GET" ? next(401) : next();
+    case "EDITOR":
+      return next();
+    default:
+      return next(401);
   }
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -10,6 +10,7 @@ export const CreateEventSchema = z
     dateStart: iso8601,
     dateEnd: iso8601,
     subTag_id: z.number().int().positive(),
+    society_id: z.number().int().positive().optional(), // set server-side from x-society-id header
     microsoft_id: z.string().optional(), // populated server-side; ignored if provided by client
   })
   .refine(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,13 @@ import {
 } from "./lib/middleware/validateMicrosoftToken";
 
 export async function middleware(req: NextRequest) {
+  // Strip any identity headers from incoming requests to prevent spoofing.
+  // We set these ourselves after the token is validated.
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.delete("x-ms-user-id");
+  requestHeaders.delete("x-society-id");
+  requestHeaders.delete("x-user-role");
+
   if (req.nextUrl.pathname === "/") {
     const token = req.cookies.get("token")?.value;
     if (!token || token === "") {
@@ -27,7 +34,6 @@ export async function middleware(req: NextRequest) {
     }
   }
   if (req.nextUrl.pathname.startsWith("/api")) {
-    // return NextResponse.next();
     const cookiesHandler = cookies().get("token")?.value;
     if (!cookiesHandler)
       return new NextResponse("Unauthorized", { status: 401 });
@@ -35,35 +41,35 @@ export async function middleware(req: NextRequest) {
       cookiesHandler
     );
     if (status === true) {
-      // Check Perms Here
       if (data?.id != null) {
+        // Forward the validated MS identity so route handlers don't need to
+        // re-call MS Graph to discover who the caller is.
+        requestHeaders.set("x-ms-user-id", data.id);
         try {
           const retrieveUser: User = await apiHandler("/user", {
             method: "POST",
             body: JSON.stringify({ microsoft_id: data.id }),
           });
+          requestHeaders.set("x-society-id", String(retrieveUser.society_id));
+          requestHeaders.set("x-user-role", retrieveUser.role);
 
           return protectedRoute(
             retrieveUser.role,
             req.method,
-            req.nextUrl.pathname
+            req.nextUrl.pathname,
+            requestHeaders
           );
         } catch (e) {
-          const response = NextResponse.redirect(
+          return NextResponse.redirect(
             new URL("/api/auth/microsoft?action=login", req.url)
           );
-          return response;
         }
-
-        // return retrieveUser;
-        // const { microsoft_id, role } = data as User;
       }
       return NextResponse.next();
     } else {
-      const response = NextResponse.redirect(
+      return NextResponse.redirect(
         new URL("/api/auth/microsoft?action=login", req.url)
       );
-      return response;
     }
   } else {
     // Token is for pages view
@@ -78,11 +84,10 @@ export async function middleware(req: NextRequest) {
     try {
       const isValidToken = await validateMicrosoftToken(token);
       if (!isValidToken) {
-        const response = NextResponse.redirect(
+        return NextResponse.redirect(
           new URL("/api/auth/microsoft?action=login", req.url),
           { status: 303 }
         );
-        return response;
       }
     } catch (error) {
       console.error("Error validating token:", error);


### PR DESCRIPTION
## Phase 3 — Architecture

Four architectural improvements: SSE pool isolation, auth header consolidation, multi-tenancy scaffolding, and component logic extraction.

---

### [F-23] Dedicated SSE connection pool (closes #13)

**Problem:** SSE LISTEN/NOTIFY clients hold a pg connection indefinitely, competing with normal API requests for the 10-slot shared pool.

**Fix:**
- Added `ssePool` (max: 30) alongside `pool` (max: 10) in `src/db/index.ts`
- SSE route imports and uses `ssePool`
- Fixed the broken `@ts-ignore` Drizzle join spread in the SSE notification handler

---

### [F-07] Consolidate auth in middleware — pass identity via headers (closes #9)

**Problem:** The events POST handler called MS Graph independently to get the caller's identity, even though the middleware had already validated the token.

**Fix:**
- Middleware strips `x-ms-user-id`, `x-society-id`, `x-user-role` from incoming requests (prevents spoofing)
- After token validation, middleware sets `x-ms-user-id: data.id`
- After user DB lookup, sets `x-society-id` and `x-user-role`
- `protectedRoute()` accepts a `Headers` param and forwards it via `NextResponse.next({ request: { headers } })`
- Events POST reads `x-ms-user-id` directly — no more redundant Graph call

---

### [F-10] Multi-tenancy: add society_id to Events (closes #11)

**Problem:** Events had no society scope; any authenticated user could see all events regardless of organisation.

**Fix:**
- Added nullable `society_id` column to Events schema
- Generated migration `0001_great_miss_america.sql`
- Unignored `src/drizzle/` in `.gitignore` so migration files are tracked
- Events GET filters by `x-society-id` header when present
- Events POST stores `society_id` from the header

> **Deploy note:** run `bun run migrate` after deploying to apply the column addition.

---

### [F-08] Extract EventForm business logic into useEventSubmit hook (closes #10)

**Problem:** EventForm.tsx had 60+ lines of API/toast logic mixed with JSX.

**Fix:**
- Created `src/lib/hooks/useEventSubmit.ts` with the full create/update/delete flow
- EventForm calls `useEventSubmit({...})` and gets back `{ onSubmit, handleDeleteEvent, isDisable }`

---

## Checklist
- [x] `bun run lint` passes (0 errors)
- [x] Migration file generated and tracked
- [x] No breaking changes to existing API behaviour
