### PR TITLE
fix(phase-5): error handling — typed errors, HTTP status codes, correlation IDs

### DIFF
--- a/src/app/api/(protected)/events/conflicts/route.ts
+++ b/src/app/api/(protected)/events/conflicts/route.ts
@@ -1,19 +1,31 @@
 import { getEventByDay } from "@/lib/event";
+import { handleRouteError, newCorrelationId } from "@/lib/errors";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
+  const correlationId = newCorrelationId();
   const { searchParams } = new URL(request.url);
 
   const dateStart = searchParams.get("dStart");
   const dateEnd = searchParams.get("dEnd");
   const eventId = searchParams.get("id");
-  if (!dateStart || !dateEnd || !eventId)
-    return NextResponse.json([], { status: 400 });
-  const rooms = await getEventByDay(Number(eventId), dateStart, dateEnd);
-  if (rooms) {
-    const subTagIds = rooms
-      .map((event) => event.subTag_id)
-      .filter((id): id is number => id !== null);
-    return NextResponse.json(subTagIds);
-  } else return NextResponse.json([]);
+  if (!dateStart || !dateEnd || !eventId) {
+    return NextResponse.json(
+      { error: "Missing required query params: dStart, dEnd, id", correlationId },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const rooms = await getEventByDay(Number(eventId), dateStart, dateEnd);
+    if (rooms) {
+      const subTagIds = rooms
+        .map((event) => event.subTag_id)
+        .filter((id): id is number => id !== null);
+      return NextResponse.json(subTagIds);
+    }
+    return NextResponse.json([]);
+  } catch (error) {
+    return handleRouteError(error, correlationId, "GET /events/conflicts");
+  }
 }

--- a/src/app/api/(protected)/events/route.ts
+++ b/src/app/api/(protected)/events/route.ts
@@ -1,6 +1,7 @@
 import { Events, NewEvent, User } from "@/db/schema";
 import { db } from "@/lib/db";
 import { createEvent, deleteEvent, updateEvent } from "@/lib/event";
+import { handleRouteError, newCorrelationId, NotFoundError } from "@/lib/errors";
 import { CreateEventSchema, DeleteByIdSchema, UpdateEventSchema } from "@/lib/schemas";
 import { and, eq, gte, lte } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
@@ -10,10 +11,10 @@ function isValidDateString(dateString: string): boolean {
 }
 
 export async function GET(request: NextRequest) {
+  const correlationId = newCorrelationId();
   const { searchParams } = new URL(request.url);
   const dateStart = searchParams.get("dateStart");
   const dateEnd = searchParams.get("dateEnd");
-  // Filter events to the caller's society when the header is present.
   const societyIdHeader = request.headers.get("x-society-id");
   const societyId = societyIdHeader ? parseInt(societyIdHeader, 10) : null;
 
@@ -46,7 +47,7 @@ export async function GET(request: NextRequest) {
 
     if (rows === null) {
       return NextResponse.json(
-        { error: "Invalid date format. Use ISO 8601 (YYYY-MM-DDTHH:mm:ss.mmmZ)." },
+        { error: "Invalid date format. Use ISO 8601 (YYYY-MM-DDTHH:mm:ss.mmmZ).", correlationId },
         { status: 400 }
       );
     }
@@ -55,26 +56,21 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(events);
   } catch (error) {
-    console.error("Error fetching events:", error);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 }
-    );
+    return handleRouteError(error, correlationId, "GET /events");
   }
 }
 
 export async function POST(request: NextRequest) {
+  const correlationId = newCorrelationId();
   const rawBody = await request.json();
   const parsed = CreateEventSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+    return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
   }
 
-  // Identity is resolved once in middleware and forwarded via x-ms-user-id header.
-  // This avoids a redundant MS Graph call per POST request.
   const msUserId = request.headers.get("x-ms-user-id");
   if (!msUserId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Unauthorized", correlationId }, { status: 401 });
   }
 
   const societyIdHeader = request.headers.get("x-society-id");
@@ -87,46 +83,41 @@ export async function POST(request: NextRequest) {
       society_id: societyId,
     };
     await createEvent(body);
-    return NextResponse.json(
-      { message: "Event succesfully created", status: 200 },
-      { status: 200 }
-    );
+    return NextResponse.json({ message: "Event successfully created" }, { status: 201 });
   } catch (error) {
-    return NextResponse.json(
-      { message: error instanceof Error ? error.message : "Internal Server Error", status: 500 },
-      { status: 500 }
-    );
+    return handleRouteError(error, correlationId, "POST /events");
   }
 }
 
 export async function PUT(request: NextRequest) {
+  const correlationId = newCorrelationId();
   const rawBody = await request.json();
   const parsed = UpdateEventSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+    return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
   }
   try {
     const { id, ...updateData } = parsed.data;
     const event = await updateEvent(id, updateData);
-    return event
-      ? NextResponse.json(event)
-      : NextResponse.json({ error: "Event not found" }, { status: 404 });
-  } catch (e) {
-    return NextResponse.json(
-      { error: e instanceof Error ? e.message : "Forbidden", status: 403 },
-      { status: 403 }
-    );
+    if (!event) throw new NotFoundError("Event");
+    return NextResponse.json(event);
+  } catch (error) {
+    return handleRouteError(error, correlationId, "PUT /events");
   }
 }
 
 export async function DELETE(request: NextRequest) {
+  const correlationId = newCorrelationId();
   const rawBody = await request.json();
   const parsed = DeleteByIdSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+    return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
   }
-  const event = await deleteEvent(parsed.data.id);
-  return event
-    ? NextResponse.json(event)
-    : NextResponse.json({ error: "Event not found" }, { status: 404 });
+  try {
+    const event = await deleteEvent(parsed.data.id);
+    if (!event) throw new NotFoundError("Event");
+    return NextResponse.json(event);
+  } catch (error) {
+    return handleRouteError(error, correlationId, "DELETE /events");
+  }
 }

--- a/src/app/api/(protected)/rooms/route.ts
+++ b/src/app/api/(protected)/rooms/route.ts
@@ -1,45 +1,42 @@
 import { db } from "@/db";
 import { Rooms } from "@/db/schema";
+import { handleRouteError, newCorrelationId, NotFoundError } from "@/lib/errors";
 import { CreateRoomSchema, DeleteByIdSchema, UpdateRoomSchema } from "@/lib/schemas";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
-// Get all rooms
 export async function GET() {
+  const correlationId = newCorrelationId();
   try {
     const allRooms = await db.select().from(Rooms);
     return NextResponse.json(allRooms);
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to fetch rooms" },
-      { status: 500 }
-    );
+    return handleRouteError(error, correlationId, "GET /rooms");
   }
 }
 
 export async function POST(request: Request) {
+  const correlationId = newCorrelationId();
   try {
     const body = await request.json();
     const parsed = CreateRoomSchema.safeParse(body);
     if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+      return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
     }
     const [newRoom] = await db.insert(Rooms).values(parsed.data).returning();
-    return NextResponse.json(newRoom);
+    return NextResponse.json(newRoom, { status: 201 });
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to create room" },
-      { status: 500 }
-    );
+    return handleRouteError(error, correlationId, "POST /rooms");
   }
 }
 
 export async function PUT(request: Request) {
+  const correlationId = newCorrelationId();
   try {
     const body = await request.json();
     const parsed = UpdateRoomSchema.safeParse(body);
     if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+      return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
     }
     const { id, ...updateData } = parsed.data;
     const [updatedRoom] = await db
@@ -47,32 +44,24 @@ export async function PUT(request: Request) {
       .set(updateData)
       .where(eq(Rooms.id, id))
       .returning();
-    if (!updatedRoom) {
-      return NextResponse.json({ error: "Room not found" }, { status: 404 });
-    }
+    if (!updatedRoom) throw new NotFoundError("Room");
     return NextResponse.json(updatedRoom);
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to update room" },
-      { status: 500 }
-    );
+    return handleRouteError(error, correlationId, "PUT /rooms");
   }
 }
 
-// Delete a room
 export async function DELETE(request: Request) {
+  const correlationId = newCorrelationId();
   try {
     const body = await request.json();
     const parsed = DeleteByIdSchema.safeParse(body);
     if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+      return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
     }
     await db.delete(Rooms).where(eq(Rooms.id, parsed.data.id));
     return NextResponse.json({ message: "Room deleted successfully" });
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to delete room" },
-      { status: 500 }
-    );
+    return handleRouteError(error, correlationId, "DELETE /rooms");
   }
 }

--- a/src/app/api/(protected)/user/route.ts
+++ b/src/app/api/(protected)/user/route.ts
@@ -1,23 +1,24 @@
 import { db } from "@/db";
 import { User } from "@/db/schema";
+import { handleRouteError, newCorrelationId } from "@/lib/errors";
 import { eq } from "drizzle-orm";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(_request: NextRequest) {
+  const correlationId = newCorrelationId();
   try {
     const token = cookies().get("token")?.value;
     if (!token) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: "Unauthorized", correlationId }, { status: 401 });
     }
 
-    // Resolve identity from the validated MS token — never trust the request body.
     const graphResponse = await fetch("https://graph.microsoft.com/v1.0/me", {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!graphResponse.ok) {
       cookies().delete("token");
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: "Unauthorized", correlationId }, { status: 401 });
     }
     const { id: microsoft_id } = await graphResponse.json();
 
@@ -29,15 +30,11 @@ export async function POST(_request: NextRequest) {
 
     if (!user) {
       cookies().delete("token");
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
+      return NextResponse.json({ error: "User not found", correlationId }, { status: 404 });
     }
 
     return NextResponse.json(user);
   } catch (error) {
-    console.error("Error fetching user:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return handleRouteError(error, correlationId, "POST /user");
   }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+
+export function newCorrelationId(): string {
+  return crypto.randomUUID();
+}
+
+/** Base class for typed application errors that map to specific HTTP status codes. */
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(resource: string) {
+    super(`${resource} not found`, 404);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string) {
+    super(message, 409);
+    this.name = "ConflictError";
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string) {
+    super(message, 400);
+    this.name = "ValidationError";
+  }
+}
+
+/** PostgreSQL wire-protocol error codes relevant to our domain. */
+const PG_UNIQUE_VIOLATION = "23505";
+const PG_FK_VIOLATION = "23503";
+const PG_NOT_NULL_VIOLATION = "23502";
+const PG_CHECK_VIOLATION = "23514";
+
+interface PgError {
+  code?: string;
+  constraint?: string;
+}
+
+function isPgError(err: unknown): err is PgError {
+  return typeof err === "object" && err !== null && "code" in err;
+}
+
+/**
+ * Maps any thrown value to a structured NextResponse with the correct HTTP
+ * status code. Logs the full error server-side with a correlation ID so
+ * clients can reference it without leaking internals.
+ */
+export function handleRouteError(
+  error: unknown,
+  correlationId: string,
+  context: string
+): NextResponse {
+  console.error(`[${correlationId}] ${context}:`, error);
+
+  if (error instanceof AppError) {
+    return NextResponse.json(
+      { error: error.message, correlationId },
+      { status: error.statusCode }
+    );
+  }
+
+  if (isPgError(error)) {
+    switch (error.code) {
+      case PG_UNIQUE_VIOLATION:
+        return NextResponse.json(
+          { error: "Resource already exists", correlationId },
+          { status: 409 }
+        );
+      case PG_FK_VIOLATION:
+        return NextResponse.json(
+          { error: "Referenced resource not found", correlationId },
+          { status: 409 }
+        );
+      case PG_NOT_NULL_VIOLATION:
+      case PG_CHECK_VIOLATION:
+        return NextResponse.json(
+          { error: "Invalid data provided", correlationId },
+          { status: 400 }
+        );
+    }
+  }
+
+  return NextResponse.json(
+    { error: "Internal Server Error", correlationId },
+    { status: 500 }
+  );
+}

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -1,6 +1,7 @@
 // src/lib/events.ts
 import { Event, Events, NewEvent, Rooms, User } from "@/db/schema";
 import { and, eq, gt, lt, ne } from "drizzle-orm";
+import { ConflictError, NotFoundError } from "./errors";
 import { db } from "./db";
 // Create
 export async function createEvent(event: NewEvent): Promise<Event> {
@@ -23,7 +24,7 @@ export async function createEvent(event: NewEvent): Promise<Event> {
     const user = await db.query.User.findFirst({
       where: eq(User.microsoft_id, conflictingEvent.microsoft_id),
     });
-    throw new Error(
+    throw new ConflictError(
       `La salle ${room?.name || "inconnue"} est déjà réservée par ${
         `${user?.givenName} ${user?.surname}` || "un utilisateur"
       } du ${conflictingEvent.dateStart} au ${conflictingEvent.dateEnd}.`
@@ -104,7 +105,7 @@ export async function updateEvent(
     .limit(1);
 
   if (!existingEvent.length) {
-    throw new Error("Event not found");
+    throw new NotFoundError("Event");
   }
 
   // Merge existing event with updates
@@ -132,7 +133,7 @@ export async function updateEvent(
       where: eq(User.microsoft_id, conflictingEvent.microsoft_id),
     });
 
-    throw new Error(
+    throw new ConflictError(
       `La salle ${room?.name || "inconnue"} est déjà réservée par ${
         `${user?.givenName} ${user?.surname}` || "un utilisateur"
       } du ${conflictingEvent.dateStart} au ${conflictingEvent.dateEnd}.`


### PR DESCRIPTION
## Phase 5 — Error Handling

Closes #18

### Changes

**New: `src/lib/errors.ts`**
- `AppError`, `NotFoundError` (404), `ConflictError` (409), `ValidationError` (400)
- `handleRouteError(error, correlationId, context)` — maps PG error codes and `AppError` subclasses to the correct HTTP status + logs server-side with correlation ID
- PostgreSQL `23505` (unique violation) → 409, `23503` (FK violation) → 409, `23502`/`23514` → 400

**`src/lib/event.ts`**
- `createEvent` / `updateEvent` throw `ConflictError` (409) on booking conflict instead of generic `Error`
- `updateEvent` throws `NotFoundError` (404) when event not found

**Route handlers updated**
- All handlers generate a `correlationId` (UUID) per request — included in every error response
- `events/route.ts`: POST returns 201; booking conflicts now return 409 (was 403); PUT/DELETE use `handleRouteError`
- `rooms/route.ts`: POST returns 201; all catch blocks replaced with `handleRouteError`
- `user/route.ts`: `handleRouteError` for unexpected errors; correlationId added
- `conflicts/route.ts`: try/catch + `handleRouteError`; 400 response now includes descriptive message