### PR TITLE
feat(phase-7): token refresh, rate limiting, audit logs

### DIFF
--- a/src/app/api/(protected)/events/route.ts
+++ b/src/app/api/(protected)/events/route.ts
@@ -2,6 +2,7 @@ import { Events, NewEvent, User } from "@/db/schema";
 import { db } from "@/lib/db";
 import { createEvent, deleteEvent, updateEvent } from "@/lib/event";
 import { handleRouteError, newCorrelationId, NotFoundError } from "@/lib/errors";
+import { logAudit } from "@/lib/audit";
 import { CreateEventSchema, DeleteByIdSchema, UpdateEventSchema } from "@/lib/schemas";
 import { and, eq, gte, lte } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
@@ -82,7 +83,15 @@ export async function POST(request: NextRequest) {
       microsoft_id: msUserId,
       society_id: societyId,
     };
-    await createEvent(body);
+    const created = await createEvent(body);
+    void logAudit({
+      action: "create",
+      resource: "event",
+      resourceId: created.id,
+      userId: msUserId,
+      societyId,
+      metadata: parsed.data,
+    });
     return NextResponse.json({ message: "Event successfully created" }, { status: 201 });
   } catch (error) {
     return handleRouteError(error, correlationId, "POST /events");
@@ -100,6 +109,14 @@ export async function PUT(request: NextRequest) {
     const { id, ...updateData } = parsed.data;
     const event = await updateEvent(id, updateData);
     if (!event) throw new NotFoundError("Event");
+    void logAudit({
+      action: "update",
+      resource: "event",
+      resourceId: id,
+      userId: request.headers.get("x-ms-user-id"),
+      societyId: request.headers.get("x-society-id") ? parseInt(request.headers.get("x-society-id")!, 10) : null,
+      metadata: updateData,
+    });
     return NextResponse.json(event);
   } catch (error) {
     return handleRouteError(error, correlationId, "PUT /events");
@@ -116,6 +133,13 @@ export async function DELETE(request: NextRequest) {
   try {
     const event = await deleteEvent(parsed.data.id);
     if (!event) throw new NotFoundError("Event");
+    void logAudit({
+      action: "delete",
+      resource: "event",
+      resourceId: parsed.data.id,
+      userId: request.headers.get("x-ms-user-id"),
+      societyId: request.headers.get("x-society-id") ? parseInt(request.headers.get("x-society-id")!, 10) : null,
+    });
     return NextResponse.json(event);
   } catch (error) {
     return handleRouteError(error, correlationId, "DELETE /events");

--- a/src/app/api/(protected)/rooms/route.ts
+++ b/src/app/api/(protected)/rooms/route.ts
@@ -1,9 +1,10 @@
 import { db } from "@/db";
 import { Rooms } from "@/db/schema";
 import { handleRouteError, newCorrelationId, NotFoundError } from "@/lib/errors";
+import { logAudit } from "@/lib/audit";
 import { CreateRoomSchema, DeleteByIdSchema, UpdateRoomSchema } from "@/lib/schemas";
 import { eq } from "drizzle-orm";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function GET() {
   const correlationId = newCorrelationId();
@@ -15,7 +16,7 @@ export async function GET() {
   }
 }
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   const correlationId = newCorrelationId();
   try {
     const body = await request.json();
@@ -24,13 +25,21 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
     }
     const [newRoom] = await db.insert(Rooms).values(parsed.data).returning();
+    void logAudit({
+      action: "create",
+      resource: "room",
+      resourceId: newRoom.id,
+      userId: request.headers.get("x-ms-user-id"),
+      societyId: request.headers.get("x-society-id") ? parseInt(request.headers.get("x-society-id")!, 10) : null,
+      metadata: parsed.data,
+    });
     return NextResponse.json(newRoom, { status: 201 });
   } catch (error) {
     return handleRouteError(error, correlationId, "POST /rooms");
   }
 }
 
-export async function PUT(request: Request) {
+export async function PUT(request: NextRequest) {
   const correlationId = newCorrelationId();
   try {
     const body = await request.json();
@@ -45,13 +54,21 @@ export async function PUT(request: Request) {
       .where(eq(Rooms.id, id))
       .returning();
     if (!updatedRoom) throw new NotFoundError("Room");
+    void logAudit({
+      action: "update",
+      resource: "room",
+      resourceId: id,
+      userId: request.headers.get("x-ms-user-id"),
+      societyId: request.headers.get("x-society-id") ? parseInt(request.headers.get("x-society-id")!, 10) : null,
+      metadata: updateData,
+    });
     return NextResponse.json(updatedRoom);
   } catch (error) {
     return handleRouteError(error, correlationId, "PUT /rooms");
   }
 }
 
-export async function DELETE(request: Request) {
+export async function DELETE(request: NextRequest) {
   const correlationId = newCorrelationId();
   try {
     const body = await request.json();
@@ -60,6 +77,13 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ error: parsed.error.flatten(), correlationId }, { status: 422 });
     }
     await db.delete(Rooms).where(eq(Rooms.id, parsed.data.id));
+    void logAudit({
+      action: "delete",
+      resource: "room",
+      resourceId: parsed.data.id,
+      userId: request.headers.get("x-ms-user-id"),
+      societyId: request.headers.get("x-society-id") ? parseInt(request.headers.get("x-society-id")!, 10) : null,
+    });
     return NextResponse.json({ message: "Room deleted successfully" });
   } catch (error) {
     return handleRouteError(error, correlationId, "DELETE /rooms");

--- a/src/app/api/auth/microsoft/route.ts
+++ b/src/app/api/auth/microsoft/route.ts
@@ -132,6 +132,19 @@ export async function GET(request: NextRequest) {
         maxAge: tokenResponse.data.expires_in,
         path: "/",
       });
+      // Store the refresh token so middleware can silently renew the session.
+      // Requires offline_access in MICROSOFT_SCOPES.
+      if (tokenResponse.data.refresh_token) {
+        response.cookies.set({
+          name: "refresh_token",
+          value: tokenResponse.data.refresh_token,
+          httpOnly: true,
+          secure: process.env.NODE_ENV !== "development",
+          sameSite: "lax",
+          maxAge: 60 * 60 * 24 * 30, // 30 days
+          path: "/",
+        });
+      }
       response.cookies.delete("oauth_state");
 
       return response;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -113,6 +113,18 @@ export const Events = pgTable(TableInfos.events, {
 export type Event = typeof Events.$inferSelect;
 export type NewEvent = typeof Events.$inferInsert;
 
+// Audit log — records every create / update / delete on events and rooms
+export const AuditLogs = pgTable("audit_logs", {
+  id: serial("id").primaryKey(),
+  action: text("action").notNull(), // "create" | "update" | "delete"
+  resource: text("resource").notNull(), // "event" | "room"
+  resourceId: integer("resource_id"),
+  userId: text("user_id"), // microsoft_id of the actor
+  societyId: integer("society_id"),
+  metadata: text("metadata"), // JSON-encoded snapshot of the mutated data
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
 // Define relations
 export const SocietiesRelations = relations(Societies, ({ one, many }) => ({
   licence: one(Licences, {

--- a/src/drizzle/0002_magical_ted_forrester.sql
+++ b/src/drizzle/0002_magical_ted_forrester.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "audit_logs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"action" text NOT NULL,
+	"resource" text NOT NULL,
+	"resource_id" integer,
+	"user_id" text,
+	"society_id" integer,
+	"metadata" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);

--- a/src/drizzle/meta/0002_snapshot.json
+++ b/src/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,513 @@
+{
+  "id": "e6ce708b-1282-424d-b34e-9b60d047e8f3",
+  "prevId": "accb0301-73be-4d73-be6e-4456725ee739",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_tag_id": {
+          "name": "sub_tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_id": {
+          "name": "microsoft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.licences": {
+      "name": "licences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_admins": {
+          "name": "max_admins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_editors": {
+          "name": "max_editors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_viewers": {
+          "name": "max_viewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_share": {
+          "name": "url_share",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.societies": {
+      "name": "societies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url_share": {
+          "name": "url_share",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licence_id": {
+          "name": "licence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sub_tags": {
+      "name": "sub_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microsoft_id": {
+          "name": "microsoft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'VIEWER'"
+        },
+        "society_id": {
+          "name": "society_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_microsoft_id_unique": {
+          "name": "users_microsoft_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "microsoft_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "EDITOR",
+        "VIEWER"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775141544169,
       "tag": "0001_great_miss_america",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775143443784,
+      "tag": "0002_magical_ted_forrester",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,33 @@
+import { db } from "@/db";
+import { AuditLogs } from "@/db/schema";
+
+export type AuditAction = "create" | "update" | "delete";
+export type AuditResource = "event" | "room";
+
+export interface AuditContext {
+  action: AuditAction;
+  resource: AuditResource;
+  resourceId?: number;
+  userId?: string | null;
+  societyId?: number | null;
+  metadata?: unknown;
+}
+
+/**
+ * Write an audit log entry. Failures are swallowed and logged to stderr so
+ * a broken audit trail never fails the primary operation.
+ */
+export async function logAudit(ctx: AuditContext): Promise<void> {
+  try {
+    await db.insert(AuditLogs).values({
+      action: ctx.action,
+      resource: ctx.resource,
+      resourceId: ctx.resourceId ?? null,
+      userId: ctx.userId ?? null,
+      societyId: ctx.societyId ?? null,
+      metadata: ctx.metadata != null ? JSON.stringify(ctx.metadata) : null,
+    });
+  } catch (err) {
+    console.error("[audit] Failed to write audit log:", err);
+  }
+}

--- a/src/lib/auth/refreshToken.ts
+++ b/src/lib/auth/refreshToken.ts
@@ -1,0 +1,70 @@
+export interface TokenResponse {
+  access_token: string;
+  /** Returned only when the `offline_access` scope is included. */
+  refresh_token?: string;
+  expires_in: number;
+}
+
+/**
+ * Exchange a refresh token for a new access (+ refresh) token pair.
+ * Returns `null` if the refresh fails (expired refresh token, revoked
+ * consent, server error) so the caller can redirect to login.
+ *
+ * Requires `offline_access` to be included in MICROSOFT_SCOPES for the
+ * MS authorization server to issue refresh tokens in the first place.
+ */
+export async function refreshAccessToken(
+  refreshToken: string
+): Promise<TokenResponse | null> {
+  const tenantId = process.env.MICROSOFT_TENANT_ID;
+  const clientId = process.env.MICROSOFT_CLIENT_ID;
+  const clientSecret = process.env.MICROSOFT_CLIENT_SECRET;
+  const scopes = process.env.MICROSOFT_SCOPES;
+
+  if (!tenantId || !clientId || !clientSecret || !scopes) {
+    console.error("refreshAccessToken: missing required env vars");
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: clientId,
+          client_secret: clientSecret,
+          scope: scopes,
+          refresh_token: refreshToken,
+          grant_type: "refresh_token",
+        }).toString(),
+      }
+    );
+
+    if (!response.ok) {
+      const err = await response.text();
+      console.error("refreshAccessToken: token endpoint error:", err);
+      return null;
+    }
+
+    return (await response.json()) as TokenResponse;
+  } catch (error) {
+    console.error("refreshAccessToken: network error:", error);
+    return null;
+  }
+}
+
+/** Parse the `exp` Unix timestamp from a JWT without verifying the signature. */
+export function parseTokenExpiry(token: string): number | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const decoded = JSON.parse(
+      Buffer.from(payload, "base64url").toString("utf8")
+    ) as { exp?: number };
+    return typeof decoded.exp === "number" ? decoded.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface RateLimitWindow {
+  timestamps: number[];
+}
+
+/** Sliding-window rate limiter backed by an in-memory Map.
+ *
+ * Note: this works correctly for single-process deployments (e.g. PM2 fork
+ * mode on one server). For multi-instance deployments, replace the Map with
+ * a shared store (e.g. Redis / Upstash).
+ */
+const windows = new Map<string, RateLimitWindow>();
+
+/** Clean up all expired windows to prevent unbounded memory growth. */
+function purgeExpiredWindows(windowMs: number): void {
+  const cutoff = Date.now() - windowMs;
+  for (const [key, win] of windows.entries()) {
+    if (win.timestamps.every((t) => t < cutoff)) windows.delete(key);
+  }
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  retryAfter: number; // seconds until the oldest request ages out of the window
+}
+
+/**
+ * Check whether `key` is within the allowed rate.
+ * @param key     Unique identifier (e.g. `"${ip}:${route}"`)
+ * @param limit   Max requests per window
+ * @param windowMs  Window size in milliseconds
+ */
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): RateLimitResult {
+  purgeExpiredWindows(windowMs);
+
+  const now = Date.now();
+  const windowStart = now - windowMs;
+
+  const win = windows.get(key) ?? { timestamps: [] };
+  win.timestamps = win.timestamps.filter((t) => t > windowStart);
+
+  if (win.timestamps.length >= limit) {
+    const oldest = win.timestamps[0]!;
+    const retryAfter = Math.ceil((oldest + windowMs - now) / 1000);
+    windows.set(key, win);
+    return { allowed: false, remaining: 0, retryAfter };
+  }
+
+  win.timestamps.push(now);
+  windows.set(key, win);
+  return { allowed: true, remaining: limit - win.timestamps.length, retryAfter: 0 };
+}
+
+/** Extract the real client IP from common proxy headers. */
+export function getClientIp(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+/** Return a 429 response with standard Retry-After header. */
+export function rateLimitedResponse(retryAfter: number): NextResponse {
+  return new NextResponse("Too Many Requests", {
+    status: 429,
+    headers: {
+      "Retry-After": String(retryAfter),
+      "X-RateLimit-Limit": "100",
+    },
+  });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,15 +2,68 @@ import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { apiHandler } from "./app/utils/apiHandler";
 import { User } from "./components/Calendar/types/types";
+import { refreshAccessToken, parseTokenExpiry } from "./lib/auth/refreshToken";
 import { protectedRoute } from "./lib/middleware/protectedRoutes";
 import {
   validateMicrosoftToken,
   validateMicrosoftTokenAndPermissions,
 } from "./lib/middleware/validateMicrosoftToken";
+import { checkRateLimit, getClientIp, rateLimitedResponse } from "./lib/rateLimit";
+
+/** Proactive refresh threshold: refresh when token has less than 5 min left. */
+const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * Attempt a proactive token refresh. Returns the new token string on success,
+ * or null if refresh is not possible / fails.
+ */
+async function tryRefresh(req: NextRequest): Promise<string | null> {
+  const refreshToken = req.cookies.get("refresh_token")?.value;
+  if (!refreshToken) return null;
+  const result = await refreshAccessToken(refreshToken);
+  return result?.access_token ?? null;
+}
+
+/** Apply new token + refresh_token cookies to an existing response. */
+function applyTokenCookies(
+  response: NextResponse,
+  tokens: { access_token: string; refresh_token?: string; expires_in: number }
+): void {
+  const isSecure = process.env.NODE_ENV !== "development";
+  response.cookies.set({
+    name: "token",
+    value: tokens.access_token,
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax",
+    maxAge: tokens.expires_in,
+    path: "/",
+  });
+  if (tokens.refresh_token) {
+    response.cookies.set({
+      name: "refresh_token",
+      value: tokens.refresh_token,
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 30,
+      path: "/",
+    });
+  }
+}
 
 export async function middleware(req: NextRequest) {
+  // ── Rate limiting ────────────────────────────────────────────────────────
+  if (req.nextUrl.pathname.startsWith("/api")) {
+    const ip = getClientIp(req);
+    const isAuthRoute = req.nextUrl.pathname.startsWith("/api/auth");
+    // Auth endpoints get a tighter limit (10 req/min) to slow brute-force.
+    const limit = isAuthRoute ? 10 : 100;
+    const result = checkRateLimit(`${ip}:${req.nextUrl.pathname}`, limit, 60_000);
+    if (!result.allowed) return rateLimitedResponse(result.retryAfter);
+  }
+
   // Strip any identity headers from incoming requests to prevent spoofing.
-  // We set these ourselves after the token is validated.
   const requestHeaders = new Headers(req.headers);
   requestHeaders.delete("x-ms-user-id");
   requestHeaders.delete("x-society-id");
@@ -37,40 +90,70 @@ export async function middleware(req: NextRequest) {
     const cookiesHandler = cookies().get("token")?.value;
     if (!cookiesHandler)
       return new NextResponse("Unauthorized", { status: 401 });
-    const { status, data } = await validateMicrosoftTokenAndPermissions(
-      cookiesHandler
-    );
-    if (status === true) {
-      if (data?.id != null) {
-        // Forward the validated MS identity so route handlers don't need to
-        // re-call MS Graph to discover who the caller is.
-        requestHeaders.set("x-ms-user-id", data.id);
-        try {
-          const retrieveUser: User = await apiHandler("/user", {
-            method: "POST",
-            body: JSON.stringify({ microsoft_id: data.id }),
-          });
-          requestHeaders.set("x-society-id", String(retrieveUser.society_id));
-          requestHeaders.set("x-user-role", retrieveUser.role);
 
-          return protectedRoute(
-            retrieveUser.role,
-            req.method,
-            req.nextUrl.pathname,
-            requestHeaders
-          );
-        } catch (e) {
-          return NextResponse.redirect(
-            new URL("/api/auth/microsoft?action=login", req.url)
-          );
+    // ── Proactive token refresh ──────────────────────────────────────────
+    let activeToken = cookiesHandler;
+    let freshTokens: Awaited<ReturnType<typeof refreshAccessToken>> | null = null;
+
+    const expiry = parseTokenExpiry(cookiesHandler);
+    if (expiry !== null && expiry - Date.now() < REFRESH_THRESHOLD_MS) {
+      const refreshToken = req.cookies.get("refresh_token")?.value;
+      if (refreshToken) {
+        const refreshResult = await refreshAccessToken(refreshToken);
+        if (refreshResult) {
+          activeToken = refreshResult.access_token;
+          freshTokens = refreshResult;
         }
       }
-      return NextResponse.next();
-    } else {
-      return NextResponse.redirect(
-        new URL("/api/auth/microsoft?action=login", req.url)
-      );
     }
+
+    const { status, data } = await validateMicrosoftTokenAndPermissions(activeToken);
+
+    // If validation fails, attempt refresh as a fallback before giving up.
+    if (!status) {
+      const newToken = await tryRefresh(req);
+      if (!newToken) {
+        return NextResponse.redirect(
+          new URL("/api/auth/microsoft?action=login", req.url)
+        );
+      }
+      activeToken = newToken;
+      const retried = await validateMicrosoftTokenAndPermissions(activeToken);
+      if (!retried.status) {
+        return NextResponse.redirect(
+          new URL("/api/auth/microsoft?action=login", req.url)
+        );
+      }
+      Object.assign(data ?? {}, retried.data);
+    }
+
+    if (data?.id != null) {
+      requestHeaders.set("x-ms-user-id", data.id as string);
+      try {
+        const retrieveUser: User = await apiHandler("/user", {
+          method: "POST",
+          body: JSON.stringify({ microsoft_id: data.id }),
+        });
+        requestHeaders.set("x-society-id", String(retrieveUser.society_id));
+        requestHeaders.set("x-user-role", retrieveUser.role);
+
+        const response = protectedRoute(
+          retrieveUser.role,
+          req.method,
+          req.nextUrl.pathname,
+          requestHeaders
+        );
+
+        // Attach refreshed token cookies to the response if we just refreshed.
+        if (freshTokens) applyTokenCookies(response, freshTokens);
+        return response;
+      } catch (e) {
+        return NextResponse.redirect(
+          new URL("/api/auth/microsoft?action=login", req.url)
+        );
+      }
+    }
+    return NextResponse.next();
   } else {
     // Token is for pages view
     const token = req.cookies.get("token")?.value;
@@ -81,13 +164,39 @@ export async function middleware(req: NextRequest) {
         { status: 303 }
       );
     }
+
+    // Proactive page-route refresh
+    const expiry = parseTokenExpiry(token);
+    if (expiry !== null && expiry - Date.now() < REFRESH_THRESHOLD_MS) {
+      const refreshToken = req.cookies.get("refresh_token")?.value;
+      if (refreshToken) {
+        const refreshResult = await refreshAccessToken(refreshToken);
+        if (refreshResult) {
+          const response = NextResponse.next();
+          applyTokenCookies(response, refreshResult);
+          return response;
+        }
+      }
+    }
+
     try {
       const isValidToken = await validateMicrosoftToken(token);
       if (!isValidToken) {
-        return NextResponse.redirect(
-          new URL("/api/auth/microsoft?action=login", req.url),
-          { status: 303 }
-        );
+        // Try refresh before redirecting to login.
+        const newToken = await tryRefresh(req);
+        if (!newToken) {
+          return NextResponse.redirect(
+            new URL("/api/auth/microsoft?action=login", req.url),
+            { status: 303 }
+          );
+        }
+        const stillValid = await validateMicrosoftToken(newToken);
+        if (!stillValid) {
+          return NextResponse.redirect(
+            new URL("/api/auth/microsoft?action=login", req.url),
+            { status: 303 }
+          );
+        }
       }
     } catch (error) {
       console.error("Error validating token:", error);


### PR DESCRIPTION
## Phase 7 — New Features

Closes #6, #20, #21

> ⚠️ **Migration required**: run `bun run migrate` to apply `0002_magical_ted_forrester.sql` (adds `audit_logs` table).

---

### F-06 — Token refresh mechanism
- **`src/lib/auth/refreshToken.ts`**: `refreshAccessToken()` calls the MS `/token` endpoint with `grant_type=refresh_token`; `parseTokenExpiry()` decodes the JWT `exp` claim without signature verification
- **OAuth callback** (`api/auth/microsoft/route.ts`): stores the `refresh_token` in an httpOnly cookie (30-day maxAge) alongside the access token — requires `offline_access` in `MICROSOFT_SCOPES`
- **Middleware**: proactive refresh when `exp < now + 5 min`; fallback refresh when Graph validation returns invalid; `applyTokenCookies()` patches new tokens onto the outgoing response transparently

### F-20 — Rate limiting
- **`src/lib/rateLimit.ts`**: sliding-window in-memory limiter keyed by `ip:path`; `purgeExpiredWindows()` prevents unbounded memory growth
- Auth routes: **10 req/min** per IP (brute-force protection); API routes: **100 req/min**
- Returns `429 Too Many Requests` with `Retry-After` header
- Note: in-memory limiter works for single-process deployments; replace `windows` Map with Redis/Upstash for multi-instance

### F-21 — Audit logging
- **`audit_logs` table**: `action`, `resource`, `resourceId`, `userId` (microsoft_id), `societyId`, `metadata` (JSON), `createdAt`
- **`src/lib/audit.ts`**: `logAudit()` — errors are swallowed so a broken audit trail never fails the primary operation
- **events/route.ts + rooms/route.ts**: `logAudit()` called fire-and-forget on every create / update / delete with actor identity from request headers