### PR TITLE
fix(#32): room filter colors — use inline backgroundColor instead of Tailwind class prefix

### DIFF
--- a/src/components/RoomFilter/roomfilter.tsx
+++ b/src/components/RoomFilter/roomfilter.tsx
@@ -11,7 +11,6 @@ const RoomSelectorItem = ({ room }: { room: Room }) => {
   const updateRoom = useCalendarStore((state) => state.updateUnwantedRoom);
   const unwantedRooms = useCalendarStore((state) => state.unwantedRooms);
   const [isOn, setisOn] = useState<"checked" | "unchecked">("checked");
-  const roomPrimary = room.color + "-300";
 
   useEffect(() => {
     if (unwantedRooms.has(room.id)) setisOn("unchecked");
@@ -36,19 +35,22 @@ const RoomSelectorItem = ({ room }: { room: Room }) => {
         <Switch.Root
           data-state={isOn}
           defaultChecked={true}
-          className={`w-[42px] h-[25px] rounded-full relative touch-none ${
-            isOn === "checked" ? roomPrimary : " bg-gray-400"
-          }`}
+          className="w-[42px] h-[25px] rounded-full relative touch-none transition-colors"
+          style={{ backgroundColor: isOn === "checked" ? (room.color ?? "#94a3b8") : "#9ca3af" }}
           id="airplane-mode"
         >
           <Switch.Thumb className="SwitchThumb" data-state={isOn} />
         </Switch.Root>
         <label
-          className="Label text-zinc-900 select-none"
+          className="Label text-zinc-900 select-none flex items-center gap-2"
           onClick={(e) => e.preventDefault()}
           htmlFor="airplane-mode"
           style={{ paddingRight: 15 }}
         >
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+            style={{ backgroundColor: room.color ?? "#94a3b8" }}
+          />
           {room.name}
         </label>
       </div>


### PR DESCRIPTION
## Summary
Fixes #32

The room filter toggle switches and room name labels were not showing room colors. The component built a Tailwind class by concatenating the hex value with `-300` (e.g. `#3B82F6-300`) — not a valid class, so no color was ever applied.

## Changes
- **Switch background**: replaced Tailwind class with `style={{ backgroundColor: room.color }}` — room hex color when on, `gray-400` when off
- **Color dot**: added a small ● dot next to each room name so color is identifiable even when the switch is toggled off

## Files
- `src/components/RoomFilter/roomfilter.tsx`