### PR TITLE
feat(#34): add Aujourd'hui button to navigate back to current week

### DIFF
--- a/src/app/calendar/store/calendarStore.tsx
+++ b/src/app/calendar/store/calendarStore.tsx
@@ -121,6 +121,16 @@ export const createCalendarStore = (initState?: Partial<ItemPreview>) => {
     updateCalendarMonthDisplayDate: (newCalendarMonthDisplayDate: Date) => {
       set(() => ({ calendarMonthDisplay: newCalendarMonthDisplayDate }));
     },
+    resetToToday: () =>
+      set(() => ({
+        dates: Array.from({ length: 5 }, (_, i) =>
+          format(
+            addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), i),
+            "yyyy-MM-dd"
+          )
+        ),
+        calendarMonthDisplay: new Date(),
+      })),
     updateTransformedAllEvents: (
       allEvents: ItemPreview["transformedAllEvents"]
     ) => set(() => ({ transformedAllEvents: allEvents })),

--- a/src/components/Calendar/main.tsx
+++ b/src/components/Calendar/main.tsx
@@ -31,6 +31,7 @@ import {
   isBefore,
   isSameDay,
   startOfDay,
+  startOfWeek,
 } from "date-fns";
 import { format, formatInTimeZone, toZonedTime } from "date-fns-tz";
 import { fr } from "date-fns/locale";
@@ -463,6 +464,13 @@ function Calendar({
           }}
         >
           <ChevronRightIcon />
+        </button>
+        <button
+          onClick={() => preview.resetToToday()}
+          disabled={isSameDay(new Date(preview.dates[0]), startOfWeek(new Date(), { weekStartsOn: 1 }))}
+          className="mr-3 px-3 py-0.5 text-sm border border-zinc-300 rounded hover:bg-zinc-100 disabled:opacity-40 disabled:cursor-default disabled:hover:bg-transparent"
+        >
+          Aujourd&apos;hui
         </button>
         {formatInTimeZone(preview.dates[0], timezone, "dd MMMM- ", {
           locale: fr,

--- a/src/components/Calendar/types/types.ts
+++ b/src/components/Calendar/types/types.ts
@@ -129,6 +129,7 @@ export type CalendarActions = {
   updatePreviewInfos: (previewInfos: ItemPreview["previewInfos"]) => void;
   updateDatesWithStart: (newStartDate: Date) => void;
   updateCalendarMonthDisplayDate: (newCalendarMonthDisplayDate: Date) => void;
+  resetToToday: () => void;
   updateCreatePreviewInfos: (
     previewInfos: ItemPreview["createPreviewInfos"]
   ) => void;


### PR DESCRIPTION
Closes #34

## Changes
- **Store**: Added `resetToToday()` action — resets `dates` and `calendarMonthDisplay` to the current Monday-based week
- **Type**: Added `resetToToday: () => void` to `CalendarActions`
- **UI**: Added "Aujourd'hui" button in the calendar header, between the chevrons and the date label
  - Greyed out and disabled when the current week is already displayed
  - Resets to today on click