### PR TITLE
fix: add "use server" to revalidateTag — fixes static generation invariant error

### DIFF
--- a/src/lib/revalidateTag.ts
+++ b/src/lib/revalidateTag.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { revalidateTag } from "next/cache";
 
 export async function shortPollingRevalidate(name: string) {


### PR DESCRIPTION
## Bug
`shortPollingRevalidate` was called from the `Calendar` client component via `setInterval`. `revalidateTag` from `next/cache` can only run in Server Actions or Route Handlers, causing:
```
Error: Invariant: static generation store missing in revalidateTag events
```

## Fix
Add `"use server"` at the top of `src/lib/revalidateTag.ts`. This converts all exported async functions to Server Actions, making them safely callable from client components.