### PR TITLE
fix: allow empty description on event create, surface 422 errors

### DIFF
--- a/src/app/data/events.ts
+++ b/src/app/data/events.ts
@@ -26,7 +26,7 @@ export interface OverlaysEvent {
 export type FormValues = {
   id?: number;
   name: string;
-  description: string;
+  description?: string;
   dateStart: string;
   dateEnd: string;
   subTag_id: number | string;

--- a/src/lib/hooks/useEventSubmit.ts
+++ b/src/lib/hooks/useEventSubmit.ts
@@ -68,7 +68,14 @@ export function useEventSubmit({
           setisModalOpen(false);
           updateSSEdata({ id: -42 }, "delete");
         } else {
-          toast.error(res?.message ?? "Erreur lors de la création", { id: toastCreate });
+          toast.error(
+            res?.error
+              ? typeof res.error === "string"
+                ? res.error
+                : "Données invalides"
+              : (res?.message ?? "Erreur lors de la création"),
+            { id: toastCreate }
+          );
         }
       } catch (error) {
         console.error("Error creating event:", error);

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -6,7 +6,7 @@ const iso8601 = z.string().datetime({ offset: true });
 export const CreateEventSchema = z
   .object({
     name: z.string().min(1).max(255),
-    description: z.string().min(1),
+    description: z.string().optional(),
     dateStart: iso8601,
     dateEnd: iso8601,
     subTag_id: z.number().int().positive(),


### PR DESCRIPTION
## Bug found in logs
```
POST /api/events 422  (×3)
```

## Root causes
1. `CreateEventSchema` required `description: z.string().min(1)` but the form never marked the field `required` — users could submit with an empty description and silently get a 422 with no toast feedback
2. The error toast in `useEventSubmit` read `res?.message` but the 422 body uses `res.error` (the Zod flatten object) — so the error was always swallowed

## Fixes
- `schemas.ts`: `description: z.string().optional()`
- `events.ts` (FormValues type): `description?: string`
- `useEventSubmit.ts`: error toast checks `res?.error` first