### PR TITLE
fix: consistent loading→success/error toasts for all event mutations

### DIFF
--- a/src/components/Calendar/calendaritem/calendaritem.tsx
+++ b/src/components/Calendar/calendaritem/calendaritem.tsx
@@ -180,15 +180,17 @@ function CalendarItem({
       const previousEventInfos = updateOneDateToProperTimeZone(eventInfos);
       const test = updateOneDateToProperTimeZone(updateStateValues);
       state.updateTransformedOneEvent(test);
+      const toastDrag = toast.loading("Enregistrement...");
       try {
         const test30 = await updateEvent(formValues, true);
         if (test30?.status === 403 && toast?.error) {
-          toast.error(test30?.error);
+          toast.error(test30?.error, { id: toastDrag });
           state.updateTransformedOneEvent(previousEventInfos);
+        } else {
+          toast.success("Évènement déplacé avec succès", { id: toastDrag });
         }
-        // if (test30.status === 403) toast.error(test30.body);
       } catch (e) {
-        toast.error("Unauthorized");
+        toast.error("Unauthorized", { id: toastDrag });
         state.updateTransformedOneEvent(previousEventInfos);
       }
     }

--- a/src/lib/hooks/useEventSubmit.ts
+++ b/src/lib/hooks/useEventSubmit.ts
@@ -86,6 +86,7 @@ export function useEventSubmit({
     } else {
       // Update
       data.id = eventInfos.id;
+      const toastUpdate = toast.loading("Chargement...");
       try {
         const res = await updateEvent(data, true);
         if (res?.status === 403) {
@@ -94,13 +95,13 @@ export function useEventSubmit({
             dates: { dateStart: "", dateEnd: "" },
             origin: "",
           });
-          toast.error(res?.error);
+          toast.error(res?.error, { id: toastUpdate });
         } else {
-          toast.success("Évènement a été modifié avec succès");
+          toast.success("Évènement modifié avec succès", { id: toastUpdate });
           setisModalOpen(false);
         }
       } catch (e) {
-        toast.error("Erreur serveur");
+        toast.error("Erreur serveur", { id: toastUpdate });
       } finally {
         setDisable(false);
       }


### PR DESCRIPTION
## Problem
Success toasts weren't showing the green react-hot-toast style in all cases.

## Root causes & fixes

| Action | Before | After |
|---|---|---|
| Create event | ✅ loading → success/error | unchanged |
| **Form update** | ❌ no loading, bare `toast.success` appeared from nowhere | ✅ `toast.loading` → `toast.success/error` with same id |
| **Drag-drop move/resize** | ❌ zero feedback on success | ✅ `toast.loading` → `toast.success/error` with same id |
| Delete | ✅ `toast.promise` | unchanged |