### PR TITLE
fix: return created event from POST /events so success toast fires

### DIFF
--- a/src/app/api/(protected)/events/route.ts
+++ b/src/app/api/(protected)/events/route.ts
@@ -92,7 +92,7 @@ export async function POST(request: NextRequest) {
       societyId,
       metadata: parsed.data,
     });
-    return NextResponse.json({ message: "Event successfully created" }, { status: 201 });
+    return NextResponse.json(created, { status: 201 });
   } catch (error) {
     return handleRouteError(error, correlationId, "POST /events");
   }


### PR DESCRIPTION
## Bug

Creating an event showed **"Event successfully created"** as a **red error toast**.

## Root cause

`POST /events` returned `{ message: 'Event successfully created' }` — no `id` field.

The client checked `res?.id != null` to decide success/error. Since `id` was missing, it always fell into the error branch and rendered `res?.message` as a red toast.

## Fix

Return the full created event object (which has an `id`) from the POST handler. `res?.id != null` is now `true` on success → green toast fires correctly.