### PR TITLE
fix: optimistically insert new event into store after creation

### DIFF
--- a/src/lib/hooks/useEventSubmit.ts
+++ b/src/lib/hooks/useEventSubmit.ts
@@ -6,7 +6,7 @@ import {
   deleteEvent,
   updateEvent,
 } from "@/app/utils/queries";
-import { EventsResponseWithParentEventsDate, Room } from "@/components/Calendar/types/types";
+import { EventsResponse, EventsResponseWithParentEventsDate, Room } from "@/components/Calendar/types/types";
 import { formatInTimeZone } from "date-fns-tz";
 import { fr } from "date-fns/locale";
 import { Dispatch, SetStateAction, useState } from "react";
@@ -16,7 +16,7 @@ interface UseEventSubmitOptions {
   eventInfos: EventsResponseWithParentEventsDate;
   roomOptions: Room[];
   setisModalOpen: Dispatch<SetStateAction<boolean>>;
-  updateSSEdata: (event: { id: number }, op: string) => void;
+  updateSSEdata: (event: EventsResponse | { id: number }, op: string) => void;
   updateIsNewPreviewDisplay: (val: boolean) => void;
   updateCreatePreviewInfos: (val: { dates: { dateStart: string; dateEnd: string }; origin: string }) => void;
 }
@@ -65,8 +65,9 @@ export function useEventSubmit({
             )}`,
             { id: toastCreate }
           );
-          setisModalOpen(false);
+          updateSSEdata(res as EventsResponse, "insert");
           updateSSEdata({ id: -42 }, "delete");
+          setisModalOpen(false);
         } else {
           toast.error(
             res?.error


### PR DESCRIPTION
## Bug

After creating an event, it didn't appear on the calendar until the user clicked/interacted with the page (triggering a re-render or the 15s poll).

## Root cause

On successful create, only `updateSSEdata({ id: -42 }, 'delete')` was called — removing the preview ghost. The real created event was **never inserted** into the Zustand store.

The previous PR (#46) made `POST /events` return the full created event object. This PR uses that response to immediately call `updateSSEdata(res, 'insert')` before removing the preview, so the event appears instantly.

## Flow after fix
1. `createEvent()` → API returns full event with id
2. `updateSSEdata(res, 'insert')` → new event appears on calendar instantly  
3. `updateSSEdata({ id: -42 }, 'delete')` → preview ghost removed
4. Modal closes + success toast