### PR TITLE
fix: attach user to POST /events response to prevent givenName crash

### DIFF
--- a/src/app/api/(protected)/events/route.ts
+++ b/src/app/api/(protected)/events/route.ts
@@ -84,6 +84,9 @@ export async function POST(request: NextRequest) {
       society_id: societyId,
     };
     const created = await createEvent(body);
+    const user = await db.query.User.findFirst({
+      where: eq(User.microsoft_id, msUserId),
+    });
     void logAudit({
       action: "create",
       resource: "event",
@@ -92,7 +95,7 @@ export async function POST(request: NextRequest) {
       societyId,
       metadata: parsed.data,
     });
-    return NextResponse.json(created, { status: 201 });
+    return NextResponse.json({ ...created, user: user ?? null }, { status: 201 });
   } catch (error) {
     return handleRouteError(error, correlationId, "POST /events");
   }

--- a/src/components/Calendar/calendaritem/EventForm.tsx
+++ b/src/components/Calendar/calendaritem/EventForm.tsx
@@ -228,8 +228,8 @@ export const EventForm = ({
                   <PersonIcon className="w-5 h-5 text-gray-400" />
                   <div>
                     <p className="text-wrap text-sm">
-                      {`Créé par ${eventInfos.user.givenName} ${
-                        eventInfos.user.surname
+                      {`Créé par ${eventInfos.user?.givenName} ${
+                        eventInfos.user?.surname
                       } le ${formatInTimeZone(
                         eventInfos.parentEventsDate.createdAt,
                         "Europe/Paris",
@@ -283,8 +283,8 @@ export const EventForm = ({
                 <PersonIcon className="w-5 h-5 text-gray-400" />
                 <div>
                   <p className="text-wrap text-sm">
-                    {`${eventInfos.user.givenName} ${
-                      eventInfos.user.surname
+                    {`${eventInfos.user?.givenName} ${
+                      eventInfos.user?.surname
                     } le ${formatInTimeZone(
                       eventInfos.parentEventsDate.createdAt,
                       "Europe/Paris",


### PR DESCRIPTION
Closes #48

## Root cause

`POST /events` returned the raw DB row with no `user` object. Clicking the newly created event crashed with `TypeError: Cannot read properties of undefined (reading 'givenName')` because `EventForm` accesses `eventInfos.user.givenName`.

## Changes

### `src/app/api/(protected)/events/route.ts`
After inserting the event, query the creator's `User` row and return `{ ...created, user }` — same shape as `GET /events` rows.

### `src/components/Calendar/calendaritem/EventForm.tsx`
Optional chaining `user?.givenName` / `user?.surname` as a defensive fallback.